### PR TITLE
Fix use-package declaration in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ specified by the variable `marginalia-classifiers`.
 ~~~ elisp
 ;; Enable richer annotations using the Marginalia package
 (use-package marginalia
+  ;; ensure the package is always loaded eagerly
+  :demand t
   ;; The :init configuration is always executed (Not lazy!)
-  :init t
+  :init
 
   ;; Must be in the :init section of use-package such that the mode gets
   ;; enabled right away. Note that this forces loading the package.


### PR DESCRIPTION
The use-package block specifies `:init t` to eagerly load the package. This isn't a valid use-package configuration since `:init` accepts sexps. 
To ensure the package is loaded on demand, I think you're looking for `:demand t` instead, although I believe it should work without it unless the user also specifies `use-package-always-defer t` in their init file.