### PR TITLE
Update README.md to correct formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ specified by the variable `marginalia-classifiers`.
   ;; Enable richer, more heavy, annotations.
   ;; E.g. M-x will show the documentation string additional to the keybinding.
   ;; By default only the keybinding is shown as annotation.
-  (setq marginalia-annotators 'marginalia-annotators-heavy))
+  (setq marginalia-annotators '(marginalia-annotators-heavy)))
 ~~~


### PR DESCRIPTION
I ran into type errors using the previous value given in the default configuration of
`marginalia-annotators` as `marginalia-annotators-heavy`.  After customizing
the variable, I found that it needs to be wrapped in a list, so I've updated the README
to reflect that.