### PR TITLE
Format ‘mode-name’ when annotating buffers.

### DIFF
--- a/marginalia.el
+++ b/marginalia.el
@@ -533,7 +533,7 @@ Similar to `marginalia-annotate-symbol', but does not show symbol class."
        (if (buffer-modified-p buffer) "*" " ")
        (if (buffer-local-value 'buffer-read-only buffer) "%" " "))
       :face 'marginalia-modified)
-     ((buffer-local-value 'mode-name buffer) :width 20 :face 'marginalia-mode)
+     ((format-mode-line (buffer-local-value 'mode-name buffer)) :width 20 :face 'marginalia-mode)
      ((when-let (file (buffer-file-name buffer))
         (abbreviate-file-name file))
       :truncate (/ marginalia-truncate-width 2)


### PR DESCRIPTION
A buffer’s mode name might use mode-line format constructs, and so should be
passed to `format-mode-line` before being displayed.

For example, I'm using Emacs master, and the `mode-name` for my init file is 

```
("ELisp" (lexical-binding (:propertize "/l" help-echo "Using lexical-binding mode") (:propertize "/d" help-echo "Using old dynamic scoping mode
mouse-1: Enable lexical-binding mode" face warning mouse-face mode-line-highlight local-map (keymap ...))))
```