### PR TITLE
marginalia-annotate-bookmark with no front context still returns filename

### DIFF
--- a/marginalia.el
+++ b/marginalia.el
@@ -519,14 +519,14 @@ Similar to `marginalia-annotate-symbol', but does not show symbol class."
 
 (defun marginalia-annotate-bookmark (cand)
   "Annotate bookmark CAND with its file name and front context string."
-  (when-let ((bm (bookmark-get-bookmark-record (assoc cand bookmark-alist)))
-             (front (alist-get 'front-context-string bm)))
-    (marginalia--fields
-     ((alist-get 'filename bm) :width 40 :face 'marginalia-file-name)
-     ((if (or (not front) (string= front ""))
-          ""
-        (concat (replace-regexp-in-string "\n" "\\\\n" front) "…"))
-      :width 20 :face 'marginalia-documentation))))
+  (when-let ((bm (bookmark-get-bookmark-record (assoc cand bookmark-alist))))
+    (let ((front (alist-get 'front-context-string bm)))
+      (marginalia--fields
+       ((alist-get 'filename bm) :width 40 :face 'marginalia-file-name)
+       ((if (or (not front) (string= front ""))
+            ""
+          (concat (replace-regexp-in-string "\n" "\\\\n" front) "…"))
+        :width 20 :face 'marginalia-documentation)))))
 
 (defun marginalia-annotate-customize-group (cand)
   "Annotate customization group CAND with its documentation string."


### PR DESCRIPTION
The `(not front)` condition in this function was also effectively never true.