### PR TITLE
Avoid annotations for host and remote path completions

### DIFF
--- a/marginalia.el
+++ b/marginalia.el
@@ -607,7 +607,7 @@ component of a full file path.
 This function returns what would be the minibuffer contents after
 using `minibuffer-force-complete' on the candidate CAND."
   (if-let (win (active-minibuffer-window))
-      (with-selected-window win
+      (with-current-buffer (window-buffer win)
         (let* ((contents (minibuffer-contents))
                (pt (- (point) (minibuffer-prompt-end)))
                (bounds (completion-boundaries
@@ -623,18 +623,29 @@ using `minibuffer-force-complete' on the candidate CAND."
     cand))
 
 (defun marginalia-annotate-file (cand)
-  "Annotate file CAND with its size, modification time and other attributes."
-  (when-let ((attributes (file-attributes (marginalia--full-candidate cand) 'string)))
-    (marginalia--fields
-     ((file-attribute-modes attributes) :face 'marginalia-file-modes)
-     ((format "%s:%s"
-              (file-attribute-user-id attributes)
-              (file-attribute-group-id attributes))
-      :width 12 :face 'marginalia-file-owner)
-     ((file-size-human-readable (file-attribute-size attributes)) :width 7 :face 'marginalia-size)
-     ((format-time-string
-       "%b %d %H:%M"
-       (file-attribute-modification-time attributes)) :face 'marginalia-date))))
+  "Annotate file CAND with its size, modification time and other attributes.
+These annotations are skipped for Tramp paths."
+  (let* ((win (active-minibuffer-window))
+         (path (when win
+                 (with-current-buffer (window-buffer win)
+                   (substitute-in-file-name
+                    (minibuffer-contents))))))
+    (if (and path (or (file-remote-p path)
+                      ;; Catch hosts completion
+                      (and (string-match ":" path)
+                           (equal (file-name-directory path) "/"))))
+        (marginalia--documentation "*tramp*")
+      (when-let ((attributes (file-attributes (marginalia--full-candidate cand) 'string)))
+        (marginalia--fields
+         ((file-attribute-modes attributes) :face 'marginalia-file-modes)
+         ((format "%s:%s"
+                  (file-attribute-user-id attributes)
+                  (file-attribute-group-id attributes))
+          :width 12 :face 'marginalia-file-owner)
+         ((file-size-human-readable (file-attribute-size attributes)) :width 7 :face 'marginalia-size)
+         ((format-time-string
+           "%b %d %H:%M"
+           (file-attribute-modification-time attributes)) :face 'marginalia-date))))))
 
 (defun marginalia-annotate-project-file (cand)
   "Annotate file CAND with its size, modification time and other attributes."


### PR DESCRIPTION
I have proceeded the way you went with #61. Maybe what annotation are shown for remote files shown should be configurable? 