### PR TITLE
Let "\<find file\>" prompts belong the `file` category

### DIFF
--- a/marginalia.el
+++ b/marginalia.el
@@ -122,6 +122,7 @@ determine it."
     ("\\<M-x\\>" . command)
     ("\\<package\\>" . package)
     ("\\<bookmark\\>" . bookmark)
+    ("\\<find file\\>" . file)
     ("\\<color\\>" . color)
     ("\\<face\\>" . face)
     ("\\<environment variable\\>" . environment-variable)


### PR DESCRIPTION
This can help in annotating many user-defined commands.

I have signed the copyright assignment.