### PR TITLE
Add short usage section to the README

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,6 +55,15 @@ commands.
   (marginalia-mode))
 #+end_src
 
+* Usage
+The annotations for elisp symbols include their symbol class. For more
+information on what the different classifications mean, see the docstring of
+~marginalia--symbol-class~.
+
+In general, to learn more about what different annotations mean, a good starting
+point is to look at ~marginalia-annotator-registry~, and follow up to the
+annotation function of whatever category you are interested in.
+
 * Adding custom annotators or classifiers
 
 Commands that support minibuffer completion use a completion table of all the


### PR DESCRIPTION
Fix #86

---

Finally this very important issue can be resolved.

Even thought this has a bit of overlap with the other sections, I think it's good to have since there are Marginalia users who don't want to create custom annotators, but still might want to understand what's going on a bit more, and could use being pointed in the right direction.