### PR TITLE
Update example `use-package` usage in `README.org`

### DIFF
--- a/README.org
+++ b/README.org
@@ -42,16 +42,15 @@ commands.
 #+begin_src emacs-lisp
 ;; Enable richer annotations using the Marginalia package
 (use-package marginalia
+  ;; The configuration is always executed (i.e., not lazy!)
+  :demand
+  
   ;; Either bind `marginalia-cycle` globally or only in the minibuffer
   :bind (("M-A" . marginalia-cycle)
          :map minibuffer-local-map
          ("M-A" . marginalia-cycle))
 
-  ;; The :init configuration is always executed (Not lazy!)
-  :init
-
-  ;; Must be in the :init section of use-package such that the mode gets
-  ;; enabled right away. Note that this forces loading the package.
+  :config
   (marginalia-mode))
 #+end_src
 


### PR DESCRIPTION
Hi,

I believe the example configuration is not using `:init` correctly, which will result in a failure to load the package in some cases (as `marginalia-mode` won't be defined at the time `:init` gets run).

Please see the concise documentation under these two headings:
* https://github.com/jwiegley/use-package#semantics-of-init-is-now-consistent
* https://github.com/jwiegley/use-package#notes-about-lazy-loading

Thanks,

Ben