### PR TITLE
Drop Emacs 26 support

### DIFF
--- a/marginalia.el
+++ b/marginalia.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Omar Antolín Camarena <omar@matem.unam.mx>, Daniel Mendler <mail@daniel-mendler.de>
 ;; Created: 2020
 ;; Version: 0.13
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; Homepage: https://github.com/minad/marginalia
 
 ;; This file is part of GNU Emacs.
@@ -870,8 +870,7 @@ These annotations are skipped for remote paths."
     (when (or (/= (user-uid) uid) (/= (group-gid) gid))
       (format "%s:%s"
               (or (user-login-name uid) uid)
-              ;; group-name was introduced on Emacs 27
-              (or (and (fboundp 'group-name) (group-name gid)) gid)))))
+              (or (group-name gid) gid)))))
 
 (defun marginalia--file-modes (attrs)
   "Return fontified file modes given the ATTRS."
@@ -919,9 +918,8 @@ These annotations are skipped for remote paths."
   "Format TIME as an absolute age."
   (let ((system-time-locale "C"))
     (format-time-string
-     ;; decoded-time-year is only available on Emacs 27, use nth 5 here.
-     (if (> (nth 5 (decode-time (current-time)))
-            (nth 5 (decode-time time)))
+     (if (> (decoded-time-year (decode-time (current-time)))
+            (decoded-time-year (decode-time time)))
          " %Y %b %d"
        "%b %d %H:%M")
      time)))
@@ -1034,9 +1032,7 @@ These annotations are skipped for remote paths."
                       (lambda (tab _) (equal (alist-get 'name tab) cand)))))
     (let* ((tab (nth index tabs))
            (ws (alist-get 'ws tab))
-           ;; window-state-buffers requires Emacs 27
-           (bufs (and (fboundp 'window-state-buffers)
-                      (window-state-buffers ws))))
+           (bufs (window-state-buffers ws)))
       ;; NOTE: When the buffer key is present in the window state
       ;; it is added in front of the window buffer list and gets duplicated.
       (when (cadr (assq 'buffer ws)) (pop bufs))


### PR DESCRIPTION
@oantolin are you in principle okay with this? I can still test against Emacs 27.1, while I don't keep Emacs 26 around anymore. I mainly use Emacs 28 now. Most of my packages already require Emacs 27.1 and I would prefer to have them on the same level. Notably Vertico required 27.1 from the start and I haven't got requests to support older Emacs versions (or maybe only once?). I would like to keep Emacs 27.1 support for longer, such that we support three versions in the future. See also https://github.com/minad/consult/commit/20606f1c88810b31bb6cc97b7ec36d317e2d1707.