### PR TITLE
Update use-package example in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,13 +44,11 @@ with [[https://github.com/oantolin/embark][Embark]] for action support and [[htt
   :bind (("M-A" . marginalia-cycle)
          :map minibuffer-local-map
          ("M-A" . marginalia-cycle))
-
-  ;; The :init configuration is always executed (Not lazy!)
-  :init
-
-  ;; Must be in the :init section of use-package such that the mode gets
-  ;; enabled right away. Note that this forces loading the package.
-  (marginalia-mode))
+  ;; `use-package' lazy loads package with `:bind' by default, use `:demand'
+  ;; to prevent this.
+  :demand
+  :config
+  (marginalia-mode 1))
 #+end_src
 
 * Information shown by the annotators


### PR DESCRIPTION
Instead of using `:init`, it is documented to use `:demand` to prevent `use-package`'s auto lazy loading.

See <https://github.com/jwiegley/use-package#notes-about-lazy-loading>.