### PR TITLE
Teach marginalia-classify-by-command-name about aliases

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,11 @@
 #+author: Omar Antolín Camarena, Daniel Mendler
 #+language: en
 
+* Development
+
+- =marginalia-classify-by-command-name=: Resolve function aliases and use the name
+  of the original command to determine the completion category.
+
 * Version 1.1 (2023-02-17)
 
 - Require the =compat= library.

--- a/marginalia.el
+++ b/marginalia.el
@@ -1113,7 +1113,10 @@ These annotations are skipped for remote paths."
 (defun marginalia-classify-by-command-name ()
   "Lookup category for current command."
   (and marginalia--command
-       (alist-get marginalia--command marginalia-command-categories)))
+       (or (alist-get marginalia--command marginalia-command-categories)
+           ;; The command can be an alias, e.g., `recentf' -> `recentf-open'.
+           (alist-get (car (last (function-alias-p marginalia--command)))
+                      marginalia-command-categories))))
 
 (defun marginalia-classify-original-category ()
   "Return original category reported by completion metadata."


### PR DESCRIPTION
It just occurred to me that the files in `M-x recentf RET` weren't annotated but the same files in `M-x recentf-open RET` where.  That's because `marginalia-command-categories` contains `recentf-open` but not `recentf` which is an alias for the former.

I've changed `marginalia-classify-by-command-name` to traverse the alias chain to resolve the real command so that only that needs to be in `marginalia-command-categories`.  That's possible only since very recently using `function-alias-p` which has a `compat.el` implementation.