### PR TITLE
fix: prevent a crash on non-symbol canditates (e.g. lambdas)

### DIFF
--- a/marginalia.el
+++ b/marginalia.el
@@ -581,6 +581,7 @@ Sometimes symbols which are not yet loaded appear in completion tables
 if `help-enable-completion-autoload' is enabled.  These symbols
 originate from the `definition-prefixes' hash table."
   (when-let* (((bound-and-true-p help-enable-completion-autoload))
+              (symbolp sym)             ;ensure that SYM has a name.
               (files (gethash (symbol-name sym) definition-prefixes)))
     (format "[Not yet loaded from %s. See `help-enable-completion-autoload'.]"
             (string-join files ", "))))


### PR DESCRIPTION
**Context**
When using `embark-bindings` (or other sources that produce anonymous commands), candidates may be raw function objects (lambdas) rather than symbols.

**The Bug**
`marginalia--definition-prefix` assumes its argument is always a symbol and calls `symbol-name` on it. When passed a lambda (e.g. from an Embark keybinding), this causes a `wrong-type-argument: symbolp` error, freezing the display loop.

**The Fix**
Added a `(symbolp sym)` guard to `marginalia--definition-prefix`. If the candidate is not a symbol, it returns `nil` safely instead of crashing.

This fixes the crash observed when viewing keybindings for anonymous commands.
